### PR TITLE
Add EFIABI and use it for runtime services

### DIFF
--- a/efi-rs.h
+++ b/efi-rs.h
@@ -40,20 +40,20 @@ typedef struct EFI_CAPSULE_HEADER {
     UINT32      CapsuleImageSize;
 } EFI_CAPSULE_HEADER;
 
-typedef EFI_STATUS (*EFI_GET_TIME)(EFI_TIME *Time, EFI_TIME_CAPABILITIES *Capabilities);
-typedef EFI_STATUS (*EFI_SET_TIME)(EFI_TIME *Time);
-typedef EFI_STATUS (*EFI_GET_WAKEUP_TIME)(BOOLEAN *Enabled, BOOLEAN *Pending, EFI_TIME *Time);
-typedef EFI_STATUS (*EFI_SET_WAKEUP_TIME)(BOOLEAN Enable, EFI_TIME *Time);
-typedef EFI_STATUS (*EFI_SET_VIRTUAL_ADDRESS_MAP)(UINTN MemoryMapSize, UINTN DescriptorSize, UINT32 DescriptorVersion, EFI_MEMORY_DESCRIPTOR *VirtualMap);
-typedef EFI_STATUS (*EFI_CONVERT_POINTER)(UINTN DebugDisposition, VOID **Address);
-typedef EFI_STATUS (*EFI_GET_VARIABLE)(CHAR16 *VariableName, EFI_GUID *VendorGuid, UINT32 *Attributes, UINTN *DataSize, VOID *Data);
-typedef EFI_STATUS (*EFI_GET_NEXT_VARIABLE_NAME)(UINTN *VariableNameSize, CHAR16 *VariableName, EFI_GUID *VendorGuid);
-typedef EFI_STATUS (*EFI_SET_VARIABLE)(CHAR16 *VariableName, EFI_GUID *VendorGuid, UINT32 Attributes, UINTN DataSize, VOID *Data);
-typedef EFI_STATUS (*EFI_GET_NEXT_HIGH_MONO_COUNT)(UINT32 *HighCount);
-typedef EFI_STATUS (*EFI_RESET_SYSTEM)(EFI_RESET_TYPE ResetType, EFI_STATUS ResetStatus, UINTN DataSize, VOID *ResetData);
-typedef EFI_STATUS (*EFI_UPDATE_CAPSULE)(EFI_CAPSULE_HEADER **CapsuleHeaderArray, UINTN CapsuleCount, EFI_PHYSICAL_ADDRESS ScatterGatherList);
-typedef EFI_STATUS (*EFI_QUERY_CAPSULE_CAPABILITIES)(EFI_CAPSULE_HEADER **CapsuleHeaderArray, UINTN CapsuleCount, UINT64 *MaximumCapsuleSize, EFI_RESET_TYPE *ResetType);
-typedef EFI_STATUS (*EFI_QUERY_VARIABLE_INFO)(UINT32 Attributes, UINT64 *MaximumVariableStorageSize, UINT64 *RemainingVariableStorageSize, UINT64 *MaximumVariableSize);
+typedef EFI_STATUS (EFIABI *EFI_GET_TIME)(EFI_TIME *Time, EFI_TIME_CAPABILITIES *Capabilities);
+typedef EFI_STATUS (EFIABI *EFI_SET_TIME)(EFI_TIME *Time);
+typedef EFI_STATUS (EFIABI *EFI_GET_WAKEUP_TIME)(BOOLEAN *Enabled, BOOLEAN *Pending, EFI_TIME *Time);
+typedef EFI_STATUS (EFIABI *EFI_SET_WAKEUP_TIME)(BOOLEAN Enable, EFI_TIME *Time);
+typedef EFI_STATUS (EFIABI *EFI_SET_VIRTUAL_ADDRESS_MAP)(UINTN MemoryMapSize, UINTN DescriptorSize, UINT32 DescriptorVersion, EFI_MEMORY_DESCRIPTOR *VirtualMap);
+typedef EFI_STATUS (EFIABI *EFI_CONVERT_POINTER)(UINTN DebugDisposition, VOID **Address);
+typedef EFI_STATUS (EFIABI *EFI_GET_VARIABLE)(CHAR16 *VariableName, EFI_GUID *VendorGuid, UINT32 *Attributes, UINTN *DataSize, VOID *Data);
+typedef EFI_STATUS (EFIABI *EFI_GET_NEXT_VARIABLE_NAME)(UINTN *VariableNameSize, CHAR16 *VariableName, EFI_GUID *VendorGuid);
+typedef EFI_STATUS (EFIABI *EFI_SET_VARIABLE)(CHAR16 *VariableName, EFI_GUID *VendorGuid, UINT32 Attributes, UINTN DataSize, VOID *Data);
+typedef EFI_STATUS (EFIABI *EFI_GET_NEXT_HIGH_MONO_COUNT)(UINT32 *HighCount);
+typedef EFI_STATUS (EFIABI *EFI_RESET_SYSTEM)(EFI_RESET_TYPE ResetType, EFI_STATUS ResetStatus, UINTN DataSize, VOID *ResetData);
+typedef EFI_STATUS (EFIABI *EFI_UPDATE_CAPSULE)(EFI_CAPSULE_HEADER **CapsuleHeaderArray, UINTN CapsuleCount, EFI_PHYSICAL_ADDRESS ScatterGatherList);
+typedef EFI_STATUS (EFIABI *EFI_QUERY_CAPSULE_CAPABILITIES)(EFI_CAPSULE_HEADER **CapsuleHeaderArray, UINTN CapsuleCount, UINT64 *MaximumCapsuleSize, EFI_RESET_TYPE *ResetType);
+typedef EFI_STATUS (EFIABI *EFI_QUERY_VARIABLE_INFO)(UINT32 Attributes, UINT64 *MaximumVariableStorageSize, UINT64 *RemainingVariableStorageSize, UINT64 *MaximumVariableSize);
 
 typedef struct EFI_RUNTIME_SERVICES {
     EFI_TABLE_HEADER                Hdr;

--- a/efi.h
+++ b/efi.h
@@ -108,6 +108,11 @@ typedef struct EFI_TABLE_HEADER {
     UINT32  Reserved;
 } EFI_TABLE_HEADER;
 
+// EFIABI can be defined to __attribute__((ms_abi)) for example
+#ifndef EFIABI
+#  define EFIABI
+#endif
+
 
 #include <efi-st.h>
 


### PR DESCRIPTION
This adds the EFIABI macro, defaulting to being empty, allowing users of `efi-rs.h` to set an ABI for the functions.

Only added it for the runtime services because OS loaders can be completely compiled with MS ABI normally, while OS kernels sometimes can't.

Usage can be seen in my OS kernel code: https://github.com/LittleFox94/lf-os_amd64/blob/master/src/kernel/efi.c#L5